### PR TITLE
fix: return original source when no inline styles are found

### DIFF
--- a/dist/parser.js
+++ b/dist/parser.js
@@ -9,6 +9,9 @@ const parse = (source, opts) => {
     const { from } = opts;
     logger_1.logger.info(`Parsing ${from}`);
     const document = (0, postcss_1.parse)("", { from });
+    // Store the original TypeScript source so the stringifier can return it
+    // unchanged when there are no inline styles to process.
+    document.raws.angularSource = sourceString;
     try {
         const allStyles = (0, get_component_metadata_1.getComponentStyles)(sourceString, from);
         logger_1.logger.info(`Located ${allStyles.length} inline styles.`);

--- a/dist/stringifier.js
+++ b/dist/stringifier.js
@@ -6,11 +6,13 @@ const logger_1 = require("./logger");
 const stringify = (node, builder) => {
     logger_1.logger.info(`Stringify called.`);
     try {
-        const nodes = node.root().nodes;
+        const root = node.root();
+        const nodes = root.nodes;
         if (nodes.length === 0) {
-            // No inline styles — return original source unchanged to prevent
-            // stylelint's fix mode from writing an empty string back to disk.
-            builder(node.source?.input?.css ?? "");
+            // No inline styles — return the original TypeScript source unchanged
+            // to prevent stylelint's fix mode from writing an empty string back
+            // to disk.
+            builder(root.raws.angularSource ?? "");
             return;
         }
         nodes.forEach((node) => {

--- a/dist/stringifier.js
+++ b/dist/stringifier.js
@@ -6,7 +6,14 @@ const logger_1 = require("./logger");
 const stringify = (node, builder) => {
     logger_1.logger.info(`Stringify called.`);
     try {
-        node.root().nodes.forEach((node) => {
+        const nodes = node.root().nodes;
+        if (nodes.length === 0) {
+            // No inline styles — return original source unchanged to prevent
+            // stylelint's fix mode from writing an empty string back to disk.
+            builder(node.source?.input?.css ?? "");
+            return;
+        }
+        nodes.forEach((node) => {
             builder(node.raws.angularCodeBefore, node);
             (0, postcss_1.stringify)(node, builder);
             builder(node.raws.angularCodeAfter, node);

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -1,4 +1,4 @@
-import { ProcessOptions, Root, parse as postcssParse, Document } from "postcss";
+import { ProcessOptions, Root, parse as postcssParse } from "postcss";
 import { getComponentStyles } from "./get-component-metadata";
 import { logger } from "./logger";
 
@@ -9,6 +9,10 @@ export const parse = (source: string, opts: ProcessOptions): Root => {
   logger.info(`Parsing ${from}`);
 
   const document = postcssParse("", { from });
+
+  // Store the original TypeScript source so the stringifier can return it
+  // unchanged when there are no inline styles to process.
+  document.raws.angularSource = sourceString;
 
   try {
     const allStyles = getComponentStyles(sourceString, from);

--- a/src/stringifier.ts
+++ b/src/stringifier.ts
@@ -5,12 +5,13 @@ export const stringify = (node: AnyNode, builder) => {
   logger.info(`Stringify called.`);
 
   try {
-    const nodes = node.root().nodes;
+    const root = node.root();
+    const nodes = root.nodes;
 
     if (nodes.length === 0) {
-      // No inline styles — return original source unchanged to prevent
-      // stylelint's fix mode from writing an empty string back to disk.
-      builder(node.source?.input?.css ?? "");
+      // No inline styles — return the original TypeScript source unchanged to
+      // prevent stylelint's fix mode from writing an empty string back to disk.
+      builder(root.raws.angularSource ?? "");
       return;
     }
 

--- a/src/stringifier.ts
+++ b/src/stringifier.ts
@@ -5,7 +5,16 @@ export const stringify = (node: AnyNode, builder) => {
   logger.info(`Stringify called.`);
 
   try {
-    node.root().nodes.forEach((node) => {
+    const nodes = node.root().nodes;
+
+    if (nodes.length === 0) {
+      // No inline styles — return original source unchanged to prevent
+      // stylelint's fix mode from writing an empty string back to disk.
+      builder(node.source?.input?.css ?? "");
+      return;
+    }
+
+    nodes.forEach((node) => {
       builder(node.raws.angularCodeBefore, node);
       postcssStringify(node, builder);
       builder(node.raws.angularCodeAfter, node);


### PR DESCRIPTION
## Problem

When stylelint runs with `--fix` on an Angular `.ts` file that uses `styleUrl` (external stylesheet) — or any plain `.ts` file with no inline styles — the stringifier produces an **empty string**. Stylelint writes that empty string back to disk, **erasing the entire file**.

Reported in issue #6.

## Root cause

**Parser**: the PostCSS document root is created by `postcss.parse("", { from })` — an empty string. The original TypeScript source is never stored anywhere on the PostCSS tree.

**Stringifier**: iterates over `node.root().nodes`. When there are no inline styles, `nodes` is an empty array, `forEach` never executes, `builder` is never called, and the output is `""`. The attempted fallback `node.source?.input?.css` also returns `""` because the root was parsed from an empty string, not the original source.

Stylelint then writes `""` back to disk.

> The CLI accidentally avoids overwriting because it skips the write step when `result.code` is falsy. The VS Code stylelint extension replaces the full document content unconditionally, so it is always affected.

## Fix

**Parser** — store the original TypeScript source in `document.raws.angularSource` before returning:

```diff
+document.raws.angularSource = sourceString;
```

**Stringifier** — when `nodes` is empty, read `root.raws.angularSource` and return the original source unchanged:

```diff
-node.root().nodes.forEach((node) => {
-  builder(node.raws.angularCodeBefore, node);
-  postcssStringify(node, builder);
-  builder(node.raws.angularCodeAfter, node);
-});
+const root = node.root();
+const nodes = root.nodes;
+
+if (nodes.length === 0) {
+  builder(root.raws.angularSource ?? "");
+  return;
+}
+
+nodes.forEach((node) => {
+  builder(node.raws.angularCodeBefore, node);
+  postcssStringify(node, builder);
+  builder(node.raws.angularCodeAfter, node);
+});
```